### PR TITLE
fix: avoid panic: assignment to entry in nil map with empty config maps for routes

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -351,6 +351,10 @@ func (c *Controller) addContinueIfNotExist(routeString string) string {
 	}
 
 	for _, route := range m {
+		if len(route) == 0 {
+			level.Warn(c.logger).Log("msg", "One of your route config is empty")
+			continue
+		}
 		route["continue"] = true
 	}
 


### PR DESCRIPTION
fix this issue: https://github.com/dbsystel/alertmanager-config-controller/issues/11